### PR TITLE
Update Infisical

### DIFF
--- a/metadata/infisical.toml
+++ b/metadata/infisical.toml
@@ -1,3 +1,3 @@
 name = "infisical"
 terraform = "registry.terraform.io/Infisical/infisical"
-version = "0.12.5"
+version = "0.15.5"


### PR DESCRIPTION
From version 0.12.5 to 0.15.5.

Infisical has deprecated their native integrations in favor of what they call secret syncs. The newer version of the provider is needed to make use of these.