### PR TITLE
feat: add google tag manager provider

### DIFF
--- a/metadata/google-tag-manager.toml
+++ b/metadata/google-tag-manager.toml
@@ -1,0 +1,3 @@
+name = "google-tag-manager"
+terraform = "registry.terraform.io/mirefly/google-tag-manager"
+version = "0.0.8"


### PR DESCRIPTION
Adds the Google Tag Manager provider

https://registry.terraform.io/providers/mirefly/google-tag-manager/latest