### PR TITLE
Add Sentry provider

### DIFF
--- a/metadata/sentry.toml
+++ b/metadata/sentry.toml
@@ -1,0 +1,3 @@
+name = "sentry"
+terraform = "registry.terraform.io/jianyuan/sentry"
+version = "0.14.13"


### PR DESCRIPTION
The official [provider](https://www.pulumi.com/registry/packages/sentry/) was last updated in 2024. This at least gives us the option to use a newer [version](https://github.com/jianyuan/terraform-provider-sentry) that seems to be maintained