### PR TITLE
Add Atlas (Ariga) database migration provider

### DIFF
--- a/metadata/atlas.toml
+++ b/metadata/atlas.toml
@@ -1,0 +1,3 @@
+name = "atlas"
+terraform = "registry.terraform.io/ariga/atlas"
+version = "0.10.1"


### PR DESCRIPTION
Adds the Atlas database migration provider by Ariga. Supports declarative and versioned schema migrations for PostgreSQL, MySQL, SQLite, and more. Terraform registry: registry.terraform.io/ariga/atlas