### PR TITLE
Bump stripe-official version to 0.2.3

### DIFF
--- a/metadata/stripe-official.toml
+++ b/metadata/stripe-official.toml
@@ -1,3 +1,3 @@
 name = "stripe-official"
 terraform = "registry.terraform.io/stripe/stripe"
-version = "0.2.1"
+version = "0.2.2"

--- a/metadata/stripe-official.toml
+++ b/metadata/stripe-official.toml
@@ -1,3 +1,3 @@
 name = "stripe-official"
 terraform = "registry.terraform.io/stripe/stripe"
-version = "0.2.2"
+version = "0.2.3"


### PR DESCRIPTION
Untested, but exact same change applied to previous version bumps of this provider.