### PR TITLE
Add turso-jpedroh provider

### DIFF
--- a/metadata/turso-jpedroh.toml
+++ b/metadata/turso-jpedroh.toml
@@ -1,0 +1,3 @@
+name = "turso-jpedroh"
+terraform = "registry.terraform.io/jpedroh/turso"
+version = "1.2.0"


### PR DESCRIPTION
The existing `turso` provider appears to be outdated and lacks the right primitives for token generation (i.e. database auth tokens get recreated on every deployment, meaning tokens accumulate in Turso unnecessarily)

The `jpedroh/turso` package on the other hand seems to be more actively maintained (last version published ~6 months ago) and exposes a dedicated DatabaseToken resource, ensuring tokens are tracked in Pulumi state and survive across deployments.

Happy to change the name of the package if needed!