### PR TITLE
Add Honeycomb Terraform provider

### DIFF
--- a/metadata/honeycomb.toml
+++ b/metadata/honeycomb.toml
@@ -1,0 +1,3 @@
+name = "honeycomb"
+terraform = "registry.terraform.io/honeycombio/honeycombio"
+version = "0.49.0"


### PR DESCRIPTION
- Add metadata file for the official Honeycomb Terraform provider (honeycombio/honeycombio)
- Pin latest stable version 0.49.0