### PR TITLE
Add incident provider metadata

### DIFF
--- a/metadata/incident.toml
+++ b/metadata/incident.toml
@@ -1,0 +1,3 @@
+name = "incident"
+terraform = "registry.terraform.io/incident-io/incident"
+version = "5.32.0"


### PR DESCRIPTION
- Add `metadata/incident.toml` for Incident.io provider with name set to `incident` (drops the `-io` suffix from the package name) while keeping the original `incident-io.toml`