### PR TITLE
Bump incident.toml to 5.35.0

### DIFF
--- a/metadata/incident.toml
+++ b/metadata/incident.toml
@@ -1,3 +1,3 @@
 name = "incident"
 terraform = "registry.terraform.io/incident-io/incident"
-version = "5.32.0"
+version = "5.35.0"


### PR DESCRIPTION
- Sync `incident.toml` version with `incident-io.toml` — was still at 5.32.0 after the initial addition