### PR TITLE
Add cloudfleet provider

### DIFF
--- a/metadata/cloudfleet.toml
+++ b/metadata/cloudfleet.toml
@@ -1,0 +1,3 @@
+name = "cloudfleet"
+terraform = "terraform.cloudfleet.ai/cloudfleet/cloudfleet"
+version = "0.1.11"


### PR DESCRIPTION
Adds the [Cloudfleet](https://cloudfleet.ai) Kubernetes Engine (CFKE) Terraform provider so it can be used from SST.

```toml
name = "cloudfleet"
terraform = "terraform.cloudfleet.ai/cloudfleet/cloudfleet"
version = "0.1.11"
```

Verified locally that `pulumi package add terraform-provider terraform.cloudfleet.ai/cloudfleet/cloudfleet` generates cleanly from Cloudfleet's custom registry, exposing `CfkeCluster`, `CfkeFleet`, `CfkeSelfManagedNode`, and data sources.